### PR TITLE
added side pots

### DIFF
--- a/web/core/player.py
+++ b/web/core/player.py
@@ -6,6 +6,9 @@ class Player():
         self.id_num = id_num
         self.current_contribution = None
         self.cards = None
+        self.invested = 0
+        self.result = 0
+        self.isFold = False
 
     def set_cards(self, cards):
         self.cards = sorted(cards, key= lambda card:card.value)
@@ -21,11 +24,7 @@ class Player():
         if self.current_contribution is None:
             self.current_contribution = 0
         self.current_contribution += amount
+        self.invested += amount
     
-    def withdraw_bank(self):
-        if self.current_contribution is not None:
-            if self.bank - self.current_contribution < 0:
-                raise ValueError("Insuffient Funds")
-            self.bank -= self.current_contribution
-
-    
+    def apply_result(self):
+        self.bank += self.result

--- a/web/core/poker_round.py
+++ b/web/core/poker_round.py
@@ -31,6 +31,7 @@ class Round():
             self.current_node = self.small_blind
     def remove_current(self):
         self.current_node.isFold = True
+        self.current_node.player.isFold = True
         self.length -= 1
        
     def get_next_player(self):

--- a/web/core/poker_round.py
+++ b/web/core/poker_round.py
@@ -25,10 +25,7 @@ class Round():
 
         curr_node.next_node = first_node
         self.big_blind = self.small_blind.next_node
-        if len(players) > 2:
-            self.current_node = self.big_blind.next_node
-        else:
-            self.current_node = self.small_blind
+        self.current_node = self.big_blind.next_node
     def remove_current(self):
         self.current_node.isFold = True
         self.current_node.player.isFold = True

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -239,7 +239,7 @@ def distribute():
                 per_player_winnings = int(per_player_winnings)
                 extra_chip_winner = [p for p in aggressors.reverse() if not p.isFold]
                 for p in winners:
-                    if p == extra_chip_winner:
+                    if p == extra_chip_winner[0]:
                         p.result +=1
                     p.result += per_player_winnings
 

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -82,8 +82,12 @@ def handle_raise(data):
     prev_high_raise = highest_current_contribution
     # on raise, the amount is the final amount the player wants to be "in" for,
     # not how much more they want to add to there contribution.
-    current_round_pot += data['amount']-current_player.current_contribution
-    current_player.bet(data['amount']-current_player.current_contribution)
+    if current_player.current_contribution is not None:
+        current_round_pot += data['amount']-current_player.current_contribution
+        current_player.bet(data['amount']-current_player.current_contribution)
+    else:
+        current_player.bet(data['amount'])
+        current_round_pot += data['amount']
     highest_current_contribution = current_player.current_contribution 
     # we already added data['amount'] to current_player.current_contribution
     broadcast_pot(current_round_pot)
@@ -304,9 +308,9 @@ def get_options():
         else:
             options = []
             options.append("fold")
-            if (current_player.current_contribution is None 
-            or highest_current_contribution == 0 or 
-            current_player.current_contribution < highest_current_contribution):
+            if (current_player.current_contribution is None or 
+            current_player.current_contribution < highest_current_contribution and
+            highest_current_contribution != 0):
                 options.append("raise")
             if (current_player.current_contribution is None 
             or current_player.current_contribution < highest_current_contribution 
@@ -314,6 +318,7 @@ def get_options():
                 options.append("call")
             if highest_current_contribution == 0:
                 options.append("check")
+                options.append("bet")
             
             emit('options for player', {'options': options, 
             'highest_contribution': highest_current_contribution},

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -18,6 +18,7 @@ class GameState(Enum):
     WINNER = 5
 
 players = []
+heads_up = False
 pot = 0
 current_round_pot = 0
 deck = Deck()
@@ -102,6 +103,7 @@ def run_next_game_state(next_game_state):
     global current_round_pot
     global player_round
     global clients
+    global heads_up
     for player in players:
         emit('withdraw', {'amount': player.current_contribution},
         room=clients[player.name])
@@ -114,11 +116,11 @@ def run_next_game_state(next_game_state):
         distribute()
     else:
         if next_game_state == GameState.FLOP:
-            flop()
+            flop(heads_up)
         elif next_game_state ==GameState.TURN:
-            turn()
+            turn(heads_up)
         elif next_game_state == GameState.RIVER:
-            river()
+            river(heads_up)
         else:
             distribute()
 
@@ -130,6 +132,7 @@ def preflop(given_players,given_clients,small_blind_amt,big_blind_amt):
     global small_blind_amount
     global big_blind_amount
     global highest_current_contribution
+    global heads_up
     players = given_players
     clients = given_clients
     small_blind = 0
@@ -143,10 +146,12 @@ def preflop(given_players,given_clients,small_blind_amt,big_blind_amt):
     current_round_pot += player_round.big_blind.current_contribution
     current_player = player_round.current_node.player
     aggressors.append(player_round.big_blind.player)
+    if len(players) == 2:
+        heads_up = True
     deal_cards()
     get_options() 
 
-def flop():
+def flop(heads_up):
     global community_cards
     global deck
     global player_round
@@ -159,13 +164,16 @@ def flop():
     broadcast_community_cards()
     for player in player_round.get_current_players():
         current_hand_strength(player,community_cards)
-    current_player_node= player_round.small_blind
-    while current_player_node.isFold:
-        current_player_node = current_player.next_node
+    if heads_up:
+        current_player_node = player_round.big_blind
+    else:
+        current_player_node= player_round.small_blind
+        while current_player_node.isFold:
+            current_player_node = current_player.next_node
     current_player = current_player_node.player
     get_options()
 
-def turn():
+def turn(heads_up):
     global community_cards
     global deck
     global player_round
@@ -174,13 +182,16 @@ def turn():
     broadcast_community_cards()
     for player in player_round.get_current_players():
         current_hand_strength(player,community_cards)
-    current_player_node= player_round.small_blind
-    while current_player_node.isFold:
-        current_player_node = current_player.next_node
+    if heads_up:
+        current_player_node = player_round.big_blind
+    else:
+        current_player_node= player_round.small_blind
+        while current_player_node.isFold:
+            current_player_node = current_player.next_node
     current_player = current_player_node.player
     get_options()
 
-def river():
+def river(heads_up):
     global community_cards
     global deck
     global player_round
@@ -189,9 +200,12 @@ def river():
     broadcast_community_cards()
     for player in player_round.get_current_players():
         current_hand_strength(player,community_cards)
-    current_player_node= player_round.small_blind
-    while current_player_node.isFold:
-        current_player_node = current_player.next_node
+    if heads_up:
+        current_player_node = player_round.big_blind
+    else:
+        current_player_node= player_round.small_blind
+        while current_player_node.isFold:
+            current_player_node = current_player.next_node
     current_player = current_player_node.player
     get_options()
 

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -60,6 +60,7 @@ def handle_call(data):
     if data['username'] is not current_player.name:
         pass
         #error
+    print(data['amount'])
     current_player.bet(data['amount'])
     current_round_pot += data['amount']
     broadcast_pot(current_round_pot)
@@ -195,6 +196,7 @@ def flop(heads_up):
         while current_player_node.isFold:
             current_player_node = current_player.next_node
     current_player = current_player_node.player
+    player_round.current_node = current_player_node
     get_options()
 
 def turn(heads_up):
@@ -214,6 +216,7 @@ def turn(heads_up):
         while current_player_node.isFold:
             current_player_node = current_player.next_node
     current_player = current_player_node.player
+    player_round.current_node = current_player_node
     get_options()
 
 def river(heads_up):
@@ -232,6 +235,7 @@ def river(heads_up):
         while current_player_node.isFold:
             current_player_node = current_player.next_node
     current_player = current_player_node.player
+    player_round.current_node = current_player_node
     get_options()
 
 def find_winners(all_players):


### PR DESCRIPTION
added side pot logic.

The way we should look at side pots:
In a poker game, there are 3 players. A  B and C.
Preflop:
Player A goes in for 30, Player B goes in for 30, and player C raises them All IN for 50.

A and B both call, and now we go to flop.
(before we go into flop, notice the total contribution of each player A-> 50, B-> 50, C->50)

Flop through River, A and B can bet as they please, but these contributions should not increase the amount that C can win. C bet 50, so total maximum result should be 150, or a 100 profit. Anything else added by A and B should stay between them two.

Add the end of betting, A-> 70, B-> 70, C->50. C has best hand of all 3.  C wins 150 total (+100).
Between A and B, B has the better hand. B wins 40 total (-50+20 is including the loss of 50 to C)
A looses 50 to C, and 20 to B putting them at a -70 result.

Let's keep track of total amount bet by each player on the player field, and then when its time to distribute winnings, we use the following algo  called distribute(). 