### PR TITLE
All in

### DIFF
--- a/web/core/player.py
+++ b/web/core/player.py
@@ -8,7 +8,7 @@ class Player():
         self.cards = None
         self.invested = 0
         self.result = 0
-        self.isFold = False
+        self.is_fold = False
 
     def set_cards(self, cards):
         self.cards = sorted(cards, key= lambda card:card.value)

--- a/web/core/poker_round.py
+++ b/web/core/poker_round.py
@@ -31,9 +31,12 @@ class Round():
         self.current_node.player.isFold = True
         self.length -= 1
        
+    def all_in(self):
+        self.current_node.isAllIn = True
+        self.current_node.player.isAllIn = True
     def get_next_player(self):
         next_node = self.current_node.next_node
-        while next_node.isFold:
+        while next_node.isFold or next_node.isAllIn:
             next_node = next_node.next_node
         self.current_node = next_node
         return next_node

--- a/web/core/poker_round.py
+++ b/web/core/poker_round.py
@@ -1,9 +1,9 @@
 class PlayerNode():
     def __init__(self, player, next_node=None):
         self.next_node = next_node
-        self.isFold = False
+        self.is_fold= False
         self.player = player
-        self.isAllIn= False
+        self.is_all_in= False
 
 class Round():
     def __init__(self, players, small_blind=0):
@@ -27,16 +27,16 @@ class Round():
         self.big_blind = self.small_blind.next_node
         self.current_node = self.big_blind.next_node
     def remove_current(self):
-        self.current_node.isFold = True
-        self.current_node.player.isFold = True
+        self.current_node.is_fold = True
+        self.current_node.player.is_fold = True
         self.length -= 1
        
-    def all_in(self):
-        self.current_node.isAllIn = True
-        self.current_node.player.isAllIn = True
+    def all_in_current_node(self):
+        self.current_node.is_all_in = True
+        
     def get_next_player(self):
         next_node = self.current_node.next_node
-        while next_node.isFold or next_node.isAllIn:
+        while next_node.is_fold or next_node.is_all_in:
             next_node = next_node.next_node
         self.current_node = next_node
         return next_node
@@ -46,7 +46,7 @@ class Round():
         current_players.append(self.current_node.player)
         pointer = self.current_node.next_node
         while pointer != self.current_node:
-            if not pointer.isFold:
+            if not pointer.is_fold:
                 current_players.append(pointer.player)
             pointer = pointer.next_node
         return current_players

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -65,6 +65,8 @@ def handle_call(data):
         #error
     print(data['amount'])
     current_player.bet(data['amount'])
+    emit('withdraw', {'username':current_player.name, 'amount': current_player.current_contribution},
+        broadcast=True)
     if current_player.bank == current_player.invested:
         number_of_all_ins+=1
         player_round.all_in()
@@ -100,6 +102,8 @@ def handle_raise(data):
     if current_player.current_contribution is not None:
         current_round_pot += data['amount']-current_player.current_contribution
         current_player.bet(data['amount']-current_player.current_contribution)
+        emit('withdraw', {'username':current_player.name, 'amount': current_player.current_contribution},
+        broadcast=True)
     else:
         current_player.bet(data['amount'])
         current_round_pot += data['amount']

--- a/web/web_driver.py
+++ b/web/web_driver.py
@@ -170,6 +170,9 @@ def preflop(given_players,given_clients,small_blind_amt,big_blind_amt):
     big_blind_amount = big_blind_amt
     highest_current_contribution = big_blind_amount
     player_round.small_blind.player.bet(small_blind_amount)
+    emit('withdraw', {'username':player_round.small_blind.player.name,
+     'amount': player_round.small_blind.player.current_contribution},
+        broadcast=True)
     if player_round.small_blind.player.invested ==player_round.small_blind.player.bank:
         print('incrementing all_ins')
         player_round.small_blind.isAllIn = True
@@ -181,6 +184,9 @@ def preflop(given_players,given_clients,small_blind_amt,big_blind_amt):
         'currentContribution': small_blind_amount
     }, broadcast=True)
     player_round.big_blind.player.bet(big_blind_amount)
+    emit('withdraw', {'username':player_round.big_blind.player.name,
+     'amount': player_round.big_blind.player.current_contribution},
+        broadcast=True)
     if player_round.big_blind.player.invested ==player_round.big_blind.player.bank:
         print('incrementing all_ins')
         player_round.big_blind.isAllIn = True


### PR DESCRIPTION
Added logic to handle "all_in" scenarios.

1) I check if a persons all_in by the "invested" field in the player object. If that matches the "bank", I know they have exhausted all funds.

2) Once they are all in, I mark the node as "all_in" and I increment my global count. When you call get_next_player, it will skip those who have folded and those who are all_in.

3) On all streets (flop, turn, river) I check if only one player is not all_in, if so, then no point of asking them to bet, so I skip to next street.
4) Think of edge cases and lets see if it works! 

I also added the withdraw emits in this P/R.